### PR TITLE
BHTTP/Protobuf indifference and logic extraction from side effects

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -135,19 +135,3 @@ func (s *gatewayResource) configHandler(w http.ResponseWriter, r *http.Request) 
 
 	metrics.ResponseStatus(r.Method, http.StatusOK)
 }
-
-/*
-type TempCompositeGateway struct {
-	bhttpGateway gatewayResource
-	protoGateway gatewayResource
-}
-
-func (s *TempCompositeGateway) gatewayHandler(w http.ResponseWriter, r *http.Request) {
-	if
-	binaryResponse, err := h.protoHandler.Handle(binaryRequest, metrics)
-	if err == nil {
-		return binaryResponse, err
-	}
-	return h.bhttpHandler.Handle(binaryRequest, metrics)
-}
-*/

--- a/gateway.go
+++ b/gateway.go
@@ -67,7 +67,10 @@ func (s *gatewayResource) gatewayHandlerLogic(r *http.Request, metrics Metrics) 
 		return s.httpError(http.StatusBadRequest, fmt.Sprintf("Unknown handler"))
 	}
 	defer r.Body.Close()
-	encryptedMessageBytes, err := ioutil.ReadAll(r.Body)
+        // TODO: Use config to define this at startup time
+        const maxRequestBodyBytes = 2 * 1024 * 1024
+        lr := io.LimitReader(r.Body, maxRequestBodyBytes)
+	encryptedMessageBytes, err := ioutil.ReadAll(lr)
 	if err != nil {
 		metrics.Fire(metricsResultInvalidContent)
 		return s.httpError(http.StatusBadRequest, fmt.Sprintf("Reading request body failed"))

--- a/gateway.go
+++ b/gateway.go
@@ -23,7 +23,7 @@ type gatewayResource struct {
 	metricsFactory        MetricsFactory
 }
 
-type HttpErr struct {
+type HTTPError struct {
 	StatusCode int
 	Message    string
 }

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -97,14 +97,21 @@ func createMockEchoGatewayServer(t *testing.T) gatewayResource {
 		gateway:    gateway,
 		appHandler: EchoAppHandler{},
 	}
-	mockProtoHTTPFilterHandler := DefaultEncapsulationHandler{
-		keyID:   FIXED_KEY_ID,
-		gateway: gateway,
-		appHandler: ProtoHTTPAppHandler{
-			httpHandler: ForbiddenCheckHttpRequestHandler{
-				FORBIDDEN_TARGET,
-			},
+	httpHandler := ForbiddenCheckHttpRequestHandler{
+		FORBIDDEN_TARGET,
+	}
+	compositeAppHandler := TempCompositeAppHandler{
+		bhttpHandler: BinaryHTTPAppHandler{
+			httpHandler: httpHandler,
 		},
+		protoHandler: ProtoHTTPAppHandler{
+			httpHandler: httpHandler,
+		},
+	}
+	mockProtoHTTPFilterHandler := DefaultEncapsulationHandler{
+		keyID:      FIXED_KEY_ID,
+		gateway:    gateway,
+		appHandler: compositeAppHandler,
 	}
 
 	encapHandlers := make(map[string]EncapsulationHandler)

--- a/handler.go
+++ b/handler.go
@@ -292,6 +292,19 @@ func (h BinaryHTTPAppHandler) Handle(binaryRequest []byte, metrics Metrics) ([]b
 	return binaryRespEnc, r
 }
 
+type TempCompositeAppHandler struct {
+	bhttpHandler BinaryHTTPAppHandler
+	protoHandler ProtoHTTPAppHandler
+}
+
+func (h TempCompositeAppHandler) Handle(binaryRequest []byte, metrics Metrics) ([]byte, error) {
+	binaryResponse, err := h.protoHandler.Handle(binaryRequest, metrics)
+	if err == nil {
+		return binaryResponse, err
+	}
+	return h.bhttpHandler.Handle(binaryRequest, metrics)
+}
+
 // HttpRequestHandler handles HTTP requests to produce responses.
 type HttpRequestHandler interface {
 	// Handle takes a http.Request and resolves it to produce a http.Response.

--- a/main.go
+++ b/main.go
@@ -154,13 +154,13 @@ func main() {
 	}
 
 	// Create the default gateway and its request handler chain
-	var defaultGateway = ohttp.NewDefaultGateway(config)
+	var bhttpGateway = ohttp.NewDefaultGateway(config)
 	var protoGateway = ohttp.NewCustomGateway(config, "message/protohttp request", "message/protohttp response")
 
 	var targetHandler = TryBothEncapsulationHandler{
 		bhttpHandler: DefaultEncapsulationHandler{
 			keyID:   configID,
-			gateway: defaultGateway,
+			gateway: bhttpGateway,
 			appHandler: BinaryHTTPAppHandler{
 				httpHandler: httpHandler,
 			},
@@ -177,14 +177,14 @@ func main() {
 	// Create the echo handler chain
 	echoHandler := DefaultEncapsulationHandler{
 		keyID:      configID,
-		gateway:    defaultGateway,
+		gateway:    protoGateway,
 		appHandler: EchoAppHandler{},
 	}
 
 	// Create the metadata handler chain
 	metadataHandler := MetadataEncapsulationHandler{
 		keyID:   configID,
-		gateway: defaultGateway,
+		gateway: protoGateway,
 	}
 
 	// Configure metrics
@@ -215,7 +215,7 @@ func main() {
 		verbose:               verbose,
 		keyID:                 configID,
 		encapsulationHandlers: handlers,
-		gateway:               defaultGateway,
+		gateway:               protoGateway,
 		debugResponse:         debugResponse,
 		metricsFactory:        metricsFactory,
 	}

--- a/main.go
+++ b/main.go
@@ -153,7 +153,14 @@ func main() {
 		allowedOrigins:     allowedOrigins,
 		logForbiddenErrors: verbose,
 	}
-
+	compositeAppHandler := TempCompositeAppHandler{
+		bhttpHandler: BinaryHTTPAppHandler{
+			httpHandler: httpHandler,
+		},
+		protoHandler: ProtoHTTPAppHandler{
+			httpHandler: httpHandler,
+		},
+	}
 	// Create the default gateway and its request handler chain
 	var gateway ohttp.Gateway
 	var targetHandler EncapsulationHandler
@@ -164,20 +171,16 @@ func main() {
 		requestLabel = "message/bhttp request"
 		responseLabel = "message/bhttp response"
 		targetHandler = DefaultEncapsulationHandler{
-			keyID:   configID,
-			gateway: gateway,
-			appHandler: BinaryHTTPAppHandler{
-				httpHandler: httpHandler,
-			},
+			keyID:      configID,
+			gateway:    gateway,
+			appHandler: compositeAppHandler,
 		}
 	} else if requestLabel == "message/protohttp request" && responseLabel == "message/protohttp response" {
 		gateway = ohttp.NewCustomGateway(config, requestLabel, responseLabel)
 		targetHandler = DefaultEncapsulationHandler{
-			keyID:   configID,
-			gateway: gateway,
-			appHandler: ProtoHTTPAppHandler{
-				httpHandler: httpHandler,
-			},
+			keyID:      configID,
+			gateway:    gateway,
+			appHandler: compositeAppHandler,
 		}
 	} else {
 		panic("Unsupported application content handler")

--- a/main.go
+++ b/main.go
@@ -155,6 +155,7 @@ func main() {
 
 	// Create the default gateway and its request handler chain
 	var defaultGateway = ohttp.NewDefaultGateway(config)
+	var protoGateway = ohttp.NewCustomGateway(config, "message/protohttp request", "message/protohttp response")
 
 	var targetHandler = TryBothEncapsulationHandler{
 		bhttpHandler: DefaultEncapsulationHandler{
@@ -166,7 +167,7 @@ func main() {
 		},
 		protoHandler: DefaultEncapsulationHandler{
 			keyID:   configID,
-			gateway: ohttp.NewCustomGateway(config, "message/protohttp request", "message/protohttp response"),
+			gateway: protoGateway,
 			appHandler: ProtoHTTPAppHandler{
 				httpHandler: httpHandler,
 			},
@@ -214,6 +215,7 @@ func main() {
 		verbose:               verbose,
 		keyID:                 configID,
 		encapsulationHandlers: handlers,
+		gateway:               defaultGateway,
 		debugResponse:         debugResponse,
 		metricsFactory:        metricsFactory,
 	}


### PR DESCRIPTION
I think its nearly impossible to proto decode and then do HttpRequest memory un-marshalling for invalid data (other format, which is bhttp) without errors. It needs to check error metrics afterwards