### PR TITLE
Fix GitHub action test name

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
 
-  build:
+  build-and-test:
+    name: Build and test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Name of the action was `build`. This is misleading, given the action is the one performing tests as well.
This commit updates the action name.