### PR TITLE
Add option for logging secrets

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ const (
 	monitoringServiceNameEnvironmentVariable = "MONITORING_SERVICE_NAME"
 	gatewayDebugEnvironmentVariable          = "GATEWAY_DEBUG"
 	gatewayVerboseEnvironmentVariable        = "VERBOSE"
+	logSecretsEnvironmentVariable            = "LOG_SECRETS"
 )
 
 type gatewayServer struct {
@@ -128,9 +129,15 @@ func main() {
 		port = defaultPort
 	}
 
+	logSecrets := getBoolEnv(logSecretsEnvironmentVariable, false)
+
 	var seed []byte
 	if seedHex := os.Getenv(secretSeedEnvironmentVariable); seedHex != "" {
-		log.Printf("Using Secret Key Seed : [%v]", seedHex)
+		if logSecrets {
+			log.Printf("Using Secret Key Seed: [%v]", seedHex)
+		} else {
+			log.Print("Using Secret Key Seed provided in environment variable")
+		}
 		var err error
 		seed, err = hex.DecodeString(seedHex)
 		if err != nil {


### PR DESCRIPTION
If a secret key seed is provided in the environment, the gateway logs it in the clear. This commit gates that behavior on a new environment variable `LOG_SECRETS`, which is off by default.

It's possible that someone out there is depending on seeing that key in their logs and would be broken by this change, so we could switch the default value of `logSecrets` to `true`. I'd also be open to never logging the secret key seed.