### PR TITLE
Build Docker image in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,24 @@
+name: docker
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+env:
+  DOCKER_BUILDKIT: 1
+
+jobs:
+  ohttp-gateway:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_ENV
+    - run: docker build \
+      --tag "privacy-gateway-server-go" \
+      --build-arg GIT_REVISION=${GIT_REVISION} \
+      -f Dockerfile \
+      .
+    - run: docker run --rm --tag "privacy-gateway-server-go" -version

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
 
 FROM gcr.io/distroless/static
 
+ARG GIT_REVISION=unknown
+LABEL revision ${GIT_REVISION}
 COPY --from=build /privacy-gateway-server /privacy-gateway-server
 
 EXPOSE 8080

--- a/main.go
+++ b/main.go
@@ -7,11 +7,13 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/hex"
+	"flag"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
+	"runtime/debug"
 	"strconv"
 	"strings"
 
@@ -58,6 +60,8 @@ const (
 	gatewayVerboseEnvironmentVariable        = "VERBOSE"
 	logSecretsEnvironmentVariable            = "LOG_SECRETS"
 )
+
+var versionFlag = flag.Bool("version", false, "print name and version to stdout")
 
 type gatewayServer struct {
 	requestLabel   string
@@ -124,6 +128,18 @@ func getStringEnv(key string, defaultVal string) string {
 }
 
 func main() {
+	flag.Parse()
+
+	if *versionFlag {
+		buildInfo, ok := debug.ReadBuildInfo()
+		if !ok {
+			log.Printf("could not determine build info")
+			os.Exit(1)
+		}
+		fmt.Printf("%s\n%+v", os.Args[0], buildInfo)
+		os.Exit(0)
+	}
+
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = defaultPort


### PR DESCRIPTION
Adds a workflow to build the included Dockerfile on PRs and merges to `main`. Additionally, adds a `-version` flag to the binary, which makes it print out `argv[0]` and the `debug.BuildInfo` ([1]) embedded in the binary. This is just so that there's some way to run the binary such that it will exit with status 0 immediately, which lets us verify in CI that the container was built properly. We also embed the git SHA into a label on the container image.

[1]: https://pkg.go.dev/runtime/debug#BuildInfo