### PR TITLE
Fix Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,9 +16,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_ENV
-    - run: docker build \
-      --tag "privacy-gateway-server-go" \
-      --build-arg GIT_REVISION=${GIT_REVISION} \
-      -f Dockerfile \
-      .
-    - run: docker run --rm --tag "privacy-gateway-server-go" -version
+    - run: |-
+        docker build \
+          --tag "privacy-gateway-server-go" \
+          --build-arg GIT_REVISION=${GIT_REVISION} \
+          -f Dockerfile \
+          .
+    - run: docker run --entrypoint /privacy-gateway-server --rm privacy-gateway-server-go -version


### PR DESCRIPTION
The `docker.yml` GitHub Actions workflow was using the wrong syntax for a YAML multiline string, causing it to fail as in [1].

[1]: https://github.com/cloudflare/privacy-gateway-server-go/actions/runs/9097813677