### PR TITLE
Update to Go 1.21

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,9 @@ on:
 jobs:
 
   build-and-test:
+    strategy:
+      matrix:
+        go-version: [ "1.21", "1.22"]
     name: Build and test
     runs-on: ubuntu-latest
     steps:
@@ -17,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22
+        go-version: ${{ matrix.go-version }}
 
     - name: Build
       run: go build -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-bookworm as build
+FROM golang:1.21-bookworm as build
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudflare/app-gateway-go
 
-go 1.17
+go 1.21
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.1.1


### PR DESCRIPTION
Use Go 1.21 in `go.mod` and the Dockerfile. Additionally, introduces a `matrix` to the `go.yml` workflow so that the project gets built and tested on Go 1.21 and 1.22. We target 1.21 so we can use `log/slog` in a subsequent change. See #61 for discussion.