### PR TITLE
Structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ The behavior of the gateway is configurable via a number of environment variable
 - ALLOWED_TARGET_ORIGINS: This environment variable contains a comma-separated list of target origin names that the gateway is allowed to access. When configured, the gateway will only attempt to resolve requests to target origins in this list. Any other request will yield a HTTP 403 Forbidden return code.
 - CERT: This environment variable is the name of a file containing the certificate (chain) used to serve TLS connections.
 - KEY: This environment variable is the name of a file containing the private key used to serve TLS connections.
+- LOG_FORMAT: This environment variable controls the format in which events are logged. Supported values are:
+	- `default`: events are run through [`slog.TextHandler`](https://pkg.go.dev/log/slog@master#TextHandler).
+	- `json`: events are run through [`slog.JSONHandler`](https://pkg.go.dev/log/slog#JSONHandler).
+- LOG_LEVEL: This environment variable controls how noisy logs are. The supported values correspond to the [`slog.Level` values](https://pkg.go.dev/log/slog@master#Level).
 - TARGET_REWRITES: This environment variable contains a JSON document instructing the gateway to rewrite the target URL found in an encapsulated request to some specified scheme and host.
 
 ### Target URL rewrites

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -108,10 +108,9 @@ func createMockEchoGatewayServer(t *testing.T) gatewayResource {
 		gateway: gateway,
 		appHandler: ProtoHTTPAppHandler{
 			httpHandler: FilteredHttpRequestHandler{
-				client:             MockHTTPRequestHandler{},
-				allowedOrigins:     allowedOrigins,
-				logForbiddenErrors: false,
-				targetRewrites:     nil,
+				client:         MockHTTPRequestHandler{},
+				allowedOrigins: allowedOrigins,
+				targetRewrites: nil,
 			},
 		},
 	}
@@ -124,10 +123,9 @@ func createMockEchoGatewayServer(t *testing.T) gatewayResource {
 		gateway: gateway,
 		appHandler: BinaryHTTPAppHandler{
 			httpHandler: FilteredHttpRequestHandler{
-				client:             MockHTTPRequestHandler{},
-				allowedOrigins:     nil,
-				logForbiddenErrors: false,
-				targetRewrites:     targetRewrites,
+				client:         MockHTTPRequestHandler{},
+				allowedOrigins: nil,
+				targetRewrites: targetRewrites,
 			},
 		},
 	}

--- a/prometheus_metrics.go
+++ b/prometheus_metrics.go
@@ -6,9 +6,10 @@ package main
 import (
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -63,8 +64,9 @@ func NewPrometheusMetricsFactory(config PrometheusConfig) (MetricsFactory, error
 	}
 
 	go func() {
-		log.Printf("Listening for Prometheus scrapes on %s:%s\n", config.Host, config.Port)
-		log.Fatal(server.ListenAndServe())
+		slog.Debug("Listening for Prometheus scrapes", "host", config.Host, "port", config.Port)
+		slog.Error("Error serving Prometheus scrapes", "error", server.ListenAndServe())
+		os.Exit(1)
 	}()
 
 	return &PrometheusMetricsFactory{metricName: config.MetricName}, nil

--- a/statsd_metrics.go
+++ b/statsd_metrics.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"time"
 
@@ -22,7 +22,7 @@ func (s *StatsDMetrics) Fire(result string) {
 
 	err := s.client.TimeInMilliseconds(s.metricsName, float64(time.Since(s.startedAt).Milliseconds()), tags, 1)
 	if err != nil {
-		log.Printf("Cannot send metrics to statsd: %s", err)
+		slog.Warn("Cannot send metrics to statsd", "error", err)
 	}
 }
 


### PR DESCRIPTION
Adopts `log/slog` (new in Go 1.21) for structured log output. The server now supports:

- environment variable `LOG_LEVEL` which may be `DEBUG`, `INFO`, `WARN`, `ERROR` and governs which messages are written to stdout
- environment variable `LOG_FORMAT` which may be `default` for text output and `json` for JSON output

Sample log output with `LOG_FORMAT=default`:

```
time=2024-05-29T23:38:10.129Z level=INFO msg="Using Secret Key Seed provided in environment variable"
```

Sample log output with `LOG_FORMAT=json` and `LOG_LEVEL=debug`:

```json
{"time":"2024-05-29T23:40:03.417537397Z","level":"INFO","msg":"Using Secret Key Seed provided in environment variable"}
{"time":"2024-05-29T23:40:03.417885447Z","level":"DEBUG","msg":"OHTTP Gateway\n----------------\nConfig endpoint: /ohttp-keys\nLegacy config endpoint: /ohttp-configs\nTarget endpoint: /gateway\n   Request content type:  message/bhttp request\n   Response content type: message/bhttp response\nEcho endpoint: /gateway-echo\nMetadata endpoint: /gateway-metadata\n----------------\n"}
{"time":"2024-05-29T23:40:03.417894997Z","level":"DEBUG","msg":"Listening without enabling TLS","port":"81"}
{"time":"2024-05-29T23:40:03.417924067Z","level":"DEBUG","msg":"Listening for Prometheus scrapes","host":"","port":"9466"}
{"time":"2024-05-29T23:40:12.905084819Z","level":"DEBUG","msg":"Handling","method":"GET","path":"/health"}
{"time":"2024-05-29T23:40:22.905008975Z","level":"DEBUG","msg":"Handling","method":"GET","path":"/health"}
{"time":"2024-05-29T23:40:32.904921768Z","level":"DEBUG","msg":"Handling","method":"GET","path":"/health"}
{"time":"2024-05-29T23:40:42.905028673Z","level":"DEBUG","msg":"Handling","method":"GET","path":"/health"}
```

Closes #61
