### PR TITLE
[WIP] Add key rotation mechanism on the OHTTP gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The behavior of the gateway is configurable via a number of environment variable
 	- `json`: events are run through [`slog.JSONHandler`](https://pkg.go.dev/log/slog#JSONHandler).
 - LOG_LEVEL: This environment variable controls how noisy logs are. The supported values correspond to the [`slog.Level` values](https://pkg.go.dev/log/slog@master#Level).
 - TARGET_REWRITES: This environment variable contains a JSON document instructing the gateway to rewrite the target URL found in an encapsulated request to some specified scheme and host.
+- KEY_ROTATION_INTERVAL: This environment variable sets the number of days before renewing the gateway private and public key pair. The default value is 0, meaning that they will never expire.
 
 ### Target URL rewrites
 

--- a/gateway.go
+++ b/gateway.go
@@ -20,6 +20,7 @@ type gatewayResource struct {
 	encapsulationHandlers map[string]EncapsulationHandler
 	debugResponse         bool
 	metricsFactory        MetricsFactory
+	keyRotationInteval    uint8
 }
 
 const (

--- a/handler.go
+++ b/handler.go
@@ -131,7 +131,7 @@ type MetadataEncapsulationHandler struct {
 	gateway ohttp.Gateway
 }
 
-// Handle attempts to decapsulate the incoming encapsulated request and, if successful, foramts
+// Handle attempts to decapsulate the incoming encapsulated request and, if successful, formats
 // metadata from the request context, and then encapsulates and returns the result.
 func (h MetadataEncapsulationHandler) Handle(outerRequest *http.Request, encapsulatedReq ohttp.EncapsulatedRequest, metrics Metrics) (ohttp.EncapsulatedResponse, error) {
 	if !h.gateway.MatchesConfig(encapsulatedReq) {

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ const (
 	logFormatEnvironmentVariable             = "LOG_FORMAT"
 	targetRewritesVariables                  = "TARGET_REWRITES"
 	prometheusConfigVariable                 = "PROMETHEUS_CONFIG"
+	configKeyRotationInterval                = "KEY_ROTATION_INTERVAL"
 
 	// Values for LOG_FORMAT environment variable
 	logFormatDefault = "default"
@@ -335,6 +336,10 @@ func main() {
 	metadataEndpoint := getStringEnv(metadataEndpointEnvVariable, defaultMetadataEndpoint)
 	healthEndpoint := getStringEnv(healthEndpointEnvVariable, defaultHealthEndpoint)
 
+	// Interval in days for the renewing of the public and private key pair of the gateway.
+	// If 0, it never expire.
+	keyRotationInterval := uint8(getUintEnv(configKeyRotationInterval, 0))
+
 	// Install configuration endpoints
 	handlers := make(map[string]EncapsulationHandler)
 	handlers[gatewayEndpoint] = targetHandler    // Content-specific handler
@@ -346,6 +351,7 @@ func main() {
 		encapsulationHandlers: handlers,
 		debugResponse:         debugResponse,
 		metricsFactory:        metricsFactory,
+		keyRotationInteval:    keyRotationInterval,
 	}
 
 	endpoints := make(map[string]string)


### PR DESCRIPTION
**What ?**

This PR introduces the ability to rotate the public/private key pair of the gateway after a defined cryptoperiod. As a result, older HPKE configurations will expire, and new ones will be generated to ensure continued secure communication.

**Why ?**
Regular key rotation enhances the overall security of the system by reducing the risk of key compromise and ensuring cryptographic best practices.

**Issue related:**  https://github.com/cloudflare/privacy-gateway-server-go/issues/11